### PR TITLE
retrieve "Open Perspective" recursively

### DIFF
--- a/javamm.swtbot.tests/src/javamm/swtbot/tests/AbstractJavammSwtbotTest.java
+++ b/javamm.swtbot.tests/src/javamm/swtbot/tests/AbstractJavammSwtbotTest.java
@@ -51,7 +51,7 @@ public class AbstractJavammSwtbotTest {
 		closeWelcomePage();
 
 		// Change the perspective via the Open Perspective dialog
-		bot.menu("Window").menu("Open Perspective").menu("Other...").click();
+		bot.menu("Open Perspective").menu("Other...").click();
 		SWTBotShell openPerspectiveShell = bot.shell("Open Perspective");
 		openPerspectiveShell.activate();
 


### PR DESCRIPTION
don't assume it's in the "Window" menu, which is not the case for the
default "Resources" perspective