### PR TITLE
Possible bug if project name differs

### DIFF
--- a/javamm.ui/src/javamm/ui/launch/JavammLaunchShortcut.xtend
+++ b/javamm.ui/src/javamm/ui/launch/JavammLaunchShortcut.xtend
@@ -86,7 +86,7 @@ class LaunchConfigurationInfo {
 
 	def configEquals(ILaunchConfiguration a) {
 		a.getAttribute(ATTR_MAIN_TYPE_NAME, "X") == clazz && 
-		a.getAttribute(ATTR_MAIN_TYPE_NAME, "X") == project &&
+		a.getAttribute(ATTR_PROJECT_NAME, "X") == project &&
 		a.type.identifier == LAUNCH_TYPE
 	}
 	


### PR DESCRIPTION
Maybe this was a bug, needs further discussion.
If the project name is different from the main-type-name every time a JavaMM-Application is executed or debugged it creates a new launchconfiguration.
I have only tested it on my DSL (which uses the same code), because i couldn't get the JavaMM DSL running out-of-the-box.
Please ignore/ delete this pull request if the project name could never differ.